### PR TITLE
Fix watch scripts in Gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -103,7 +103,7 @@ module.exports = function(grunt) {
             //  watch for JS changes
             scripts: {
                 files: ['src/js/*.js'],
-                tasks: ['concat', 'uglify,'],
+                tasks: ['concat', 'uglify'],
                 options: {
                     spawn: false,                   
                     livereload: true


### PR DESCRIPTION
There was an extra comma, which broke the watch task for scripts.